### PR TITLE
feat: water_probe_acquanativa_ap3 component definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,3 +9,8 @@ include(water_probe_acquanativa_ap3Base)
 # FIND_PACKAGE(KDL)
 # FIND_PACKAGE(OCL)
 
+if (ROCK_TEST_ENABLED)
+    enable_testing()
+    find_package(Syskit REQUIRED)
+    syskit_orogen_tests(test)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(water_probe_acquanativa_ap3 VERSION 0.0)
 
+set(CMAKE_CXX_STANDARD 14)
+
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/.orogen/config")
 include(water_probe_acquanativa_ap3Base)
 

--- a/manifest.xml
+++ b/manifest.xml
@@ -16,4 +16,5 @@
   -->
   <depend package="drivers/orogen/iodrivers_base" />
   <depend package="drivers/water_probe_acquanativa_ap3" />
+  <test_depend name="tools/syskit" />
 </package>

--- a/manifest.xml
+++ b/manifest.xml
@@ -14,5 +14,6 @@
   <depend package="dummy-dependency-n-1" />
   <depend package="dummy-dependency-n" />
   -->
+  <depend package="drivers/orogen/iodrivers_base" />
   <depend package="drivers/water_probe_acquanativa_ap3" />
 </package>

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -31,12 +31,11 @@ bool Task::configureHook()
     std::unique_ptr<Driver> driver( new Driver(device_modbus_address));
 
     iodrivers_base::ConfigureGuard guard(this);
-    const std::string device_port = _io_port.get();
-    if(!device_port.empty()){
-        driver->openURI(device_port);
-    }
-    setDriver(driver.get());
 
+    const std::string device_port = _io_port.get();
+    driver->openURI(device_port);
+
+    setDriver(driver.get());
     if (! TaskBase::configureHook())
         return false;
 

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -66,13 +66,11 @@ void Task::cleanupHook()
     TaskBase::cleanupHook();
 }
 
-void 
+void
 Task::processIO()
 {
-    if(_data.connected())    {
-        water_probe_acquanativa_ap3::ProbeMeasurements sample(
-            m_driver->getMeasurements()
-        );
-        _data.write(sample);
-    }
+    water_probe_acquanativa_ap3::ProbeMeasurements sample(
+        m_driver->getMeasurements()
+    );
+    _data.write(sample);
 }

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -1,11 +1,13 @@
 /* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
 
 #include "Task.hpp"
+#include <memory>
 
 using namespace water_probe_acquanativa_ap3;
 
 Task::Task(std::string const& name)
     : TaskBase(name)
+    , m_driver(nullptr)
 {
 }
 
@@ -23,6 +25,9 @@ bool Task::configureHook()
 {
     if (! TaskBase::configureHook())
         return false;
+
+    m_driver = std::make_unique<Driver>(_device_address.get());
+
     return true;
 }
 bool Task::startHook()
@@ -34,6 +39,12 @@ bool Task::startHook()
 void Task::updateHook()
 {
     TaskBase::updateHook();
+
+    if(_data.connected())
+    {
+        water_probe_acquanativa_ap3::ProbeMeasurements sample;
+        _data.write(sample);
+    }
 }
 void Task::errorHook()
 {

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -1,6 +1,7 @@
 /* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
 
 #include "Task.hpp"
+#include <iodrivers_base/ConfigureGuard.hpp>
 #include <memory>
 
 using namespace water_probe_acquanativa_ap3;
@@ -23,13 +24,24 @@ Task::~Task()
 
 bool Task::configureHook()
 {
+    std::unique_ptr<Driver> driver( new Driver(_device_address.get()));
+
+    iodrivers_base::ConfigureGuard guard(this);
+    const std::string device_port = _io_port.get();
+    if(!device_port.empty()){
+        driver->openURI(device_port);
+    }
+    setDriver(driver.get());
+
     if (! TaskBase::configureHook())
         return false;
 
-    m_driver = std::make_unique<Driver>(_device_address.get());
+    m_driver = std::move(driver);
+    guard.commit();
 
     return true;
 }
+
 bool Task::startHook()
 {
     if (! TaskBase::startHook())

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -58,7 +58,7 @@ void Task::updateHook()
     water_probe_acquanativa_ap3::ProbeMeasurements sample(
         m_driver->getMeasurements()
     );
-    _data.write(sample);
+    _probe_measurements.write(sample);
 }
 void Task::errorHook()
 {

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -76,4 +76,6 @@ void Task::cleanupHook()
 void
 Task::processIO()
 {
+    // Because that Modbus is a master/slave protocol, this method is never called in the
+    // iodrivers_base::Task. So it is left empty.
 }

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -55,7 +55,10 @@ bool Task::startHook()
 void Task::updateHook()
 {
     TaskBase::updateHook();
-
+    water_probe_acquanativa_ap3::ProbeMeasurements sample(
+        m_driver->getMeasurements()
+    );
+    _data.write(sample);
 }
 void Task::errorHook()
 {
@@ -73,8 +76,4 @@ void Task::cleanupHook()
 void
 Task::processIO()
 {
-    water_probe_acquanativa_ap3::ProbeMeasurements sample(
-        m_driver->getMeasurements()
-    );
-    _data.write(sample);
 }

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -24,7 +24,11 @@ Task::~Task()
 
 bool Task::configureHook()
 {
-    std::unique_ptr<Driver> driver( new Driver(_device_address.get()));
+    const int device_modbus_address = _device_address.get();
+    if(device_modbus_address < 0) {
+        return false;
+    }
+    std::unique_ptr<Driver> driver( new Driver(device_modbus_address));
 
     iodrivers_base::ConfigureGuard guard(this);
     const std::string device_port = _io_port.get();

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -33,7 +33,8 @@ bool Task::configureHook()
     iodrivers_base::ConfigureGuard guard(this);
 
     const std::string device_port = _io_port.get();
-    driver->openURI(device_port);
+    if(not device_port.empty())
+        driver->openURI(device_port);
 
     setDriver(driver.get());
     if (! TaskBase::configureHook())

--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -52,11 +52,6 @@ void Task::updateHook()
 {
     TaskBase::updateHook();
 
-    if(_data.connected())
-    {
-        water_probe_acquanativa_ap3::ProbeMeasurements sample;
-        _data.write(sample);
-    }
 }
 void Task::errorHook()
 {
@@ -69,4 +64,15 @@ void Task::stopHook()
 void Task::cleanupHook()
 {
     TaskBase::cleanupHook();
+}
+
+void 
+Task::processIO()
+{
+    if(_data.connected())    {
+        water_probe_acquanativa_ap3::ProbeMeasurements sample(
+            m_driver->getMeasurements()
+        );
+        _data.write(sample);
+    }
 }

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -4,6 +4,7 @@
 #define WATER_PROBE_ACQUANATIVA_AP3_TASK_TASK_HPP
 
 #include "water_probe_acquanativa_ap3/TaskBase.hpp"
+#include <water_probe_acquanativa_ap3/Driver.hpp>
 
 namespace water_probe_acquanativa_ap3{
 
@@ -28,7 +29,7 @@ tasks/Task.cpp, and will be put in the water_probe_acquanativa_ap3 namespace.
     {
 	friend class TaskBase;
     protected:
-
+        std::unique_ptr<Driver> m_driver;
 
 
     public:

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -100,6 +100,8 @@ tasks/Task.cpp, and will be put in the water_probe_acquanativa_ap3 namespace.
          * before calling start() again.
          */
         void cleanupHook();
+
+        void processIO() override;
     };
 }
 

--- a/test/modbus_helpers.rb
+++ b/test/modbus_helpers.rb
@@ -1,0 +1,167 @@
+# frozen_string_literal: true
+
+# Helpers to deal with the component's expected modbus replies
+#
+# It is based on a register dictionary, and "emulates" the device by
+# automatically reading/writing values to this dictionary
+#
+# In modbus_configure_and_start, the component might go "a little
+# bit further" than the start, and actually read the speed but
+# not finish a complete state update. The tests would then "finish"
+# the state update and the sample would have a zero speed.
+#
+#   Component             Syskit
+#   --------              ------
+#                         ENTER modbus_configure_and_start
+#   ENTER startHook       |
+#   EXIT startHook        |
+#   ENTER updateHook      |
+#   READ register 2       |
+#   |                     EXIT modbus_configure_and_start
+#   |                     ENTER test
+#   READ other registers  |
+#   WRITE sample          |
+#   |                     have_one_new_sample -> speed == 0
+#   EXIT updateHook
+#
+# To handle this, either look for an eventual behavior (using for instance the
+# filtered version of have_one_new_sample, or the achieve expectation), or set
+# the modbus dictionary entries before the start.
+module ModbusHelpers
+    def setup
+        super
+
+        @modbus_registers = {}
+    end
+
+    def iodrivers_base_prepare(model)
+        task = syskit_deploy(model)
+        syskit_start_execution_agents(task)
+        reader = syskit_create_reader(task.io_raw_out_port, type: :buffer, size: 10)
+        writer = syskit_create_writer(task.io_raw_in_port)
+
+        [task, reader, writer]
+    end
+
+    def modbus_helpers_setup(task, reader, writer)
+        @__modbus_task = task
+        @__modbus_reader = reader
+        @__modbus_writer = writer
+    end
+
+    def modbus_stop_task
+        expect_execution { task.stop! }
+            .join_all_waiting_work(false)
+            .poll do
+                while (sample = @__modbus_reader.read_new)
+                    @__modbus_writer.write(modbus_reply(sample))
+                end
+            end
+            .to { emit task.stop_event }
+    end
+
+    def modbus_expect_during_configuration_and_start(&block)
+        expect_execution(&block)
+            .scheduler(true)
+            .join_all_waiting_work(false)
+            .poll do
+                while (sample = @__modbus_reader.read_new)
+                    @__modbus_writer.write(modbus_reply(sample))
+                end
+            end
+    end
+
+    # Configure and start the modbus component given to {#modbus_helpers_setup}
+    #
+    # See the {ModbusHelpers} documentation for caveats w.r.t. expectations and
+    # starting the component
+    def modbus_configure_and_start
+        modbus_expect_during_configuration_and_start.to { emit task.start_event }
+    end
+
+    def modbus_set(register, value)
+        @modbus_registers[register] = value
+    end
+
+    def modbus_get(register)
+        @modbus_registers.fetch(register)
+    rescue KeyError
+        raise ArgumentError, "register #{register} not set"
+    end
+
+    def modbus_expect_execution(writer, reader, &block)
+        expect_execution(&block)
+            .join_all_waiting_work(false)
+            .poll do
+                while (s = reader.read_new)
+                    writer.write(modbus_reply(s))
+                end
+            end
+    end
+
+    def modbus_reply_until(writer, reader)
+        sample = nil
+        expect_execution
+            .join_all_waiting_work(false)
+            .poll do
+                while !sample && (s = reader.read_new)
+                    writer.write(modbus_reply(s))
+                    sample = s if yield(s)
+                end
+            end
+            .to { achieve { sample } }
+    end
+
+    def modbus_write?(sample, register: nil, value: nil)
+        return unless sample.data[1] == 6
+
+        actual_register = sample.data[2] << 8 | sample.data[3]
+        actual_value = sample.data[4] << 8 | sample.data[5]
+
+        (!register || register == actual_register) &&
+            (!value || value == actual_value)
+    end
+
+    def modbus_reply(sample)
+        reply = [sample.data[0], sample.data[1]]
+
+        function = sample.data[1]
+        if function == 6 # write
+            address = sample.data[2] << 8 | sample.data[3]
+            value = sample.data[4] << 8 | sample.data[5]
+            @modbus_registers[address] = value
+        elsif [3, 4].include?(function) # Read registers
+            start_address  = sample.data[2] << 8 | sample.data[3]
+            register_count = sample.data[4] << 8 | sample.data[5]
+
+            reply << register_count * 2
+            register_count.times do |i|
+                register_value = modbus_get(start_address + i)
+                reply += [register_value].pack("s>").unpack("C*")
+            end
+        end
+        reply += modbus_crc(reply)
+        Types.iodrivers_base.RawPacket.new(time: Time.now, data: reply)
+    end
+
+    def modbus_reply_to_write(id)
+        reply = [id, 6]
+        reply += modbus_crc(reply)
+        Types.iodrivers_base.RawPacket.new(time: Time.now, data: reply)
+    end
+
+    def modbus_crc(data)
+        crc = 0xFFFF
+        data.each do |byte|
+            crc ^= byte
+
+            8.times do
+                odd = crc.odd?
+                crc >>= 1
+                crc ^= 0xA001 if odd
+            end
+        end
+
+        [crc & 0xFF, (crc & 0xFF00) >> 8]
+    end
+end

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -100,7 +100,8 @@ describe OroGen.water_probe_acquanativa_ap3.Task do
                 have_one_new_sample task.probe_measurements_port
             end
             now = Time.now
-            assert_in_delta(now, sample.time, Time.now - read_request_time)
+            dt = now - read_request_time
+            assert_in_delta(now, sample.time, dt)
         end
 
         it "successfully read all measurements" do

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -1,30 +1,37 @@
 using_task_library "iodrivers_base"
 require "iodrivers_base/orogen_test_helpers"
 
+require_relative "modbus_helpers.rb"
+
 using_task_library "water_probe_acquanativa_ap3"
 import_types_from "water_probe_acquanativa_ap3"
+
 
 describe OroGen.water_probe_acquanativa_ap3.Task do
     include IODriversBase::OroGenTestHelpers
 
     run_live
+
     attr_reader :task
+    attr_reader :reader
+    attr_reader :writer
+
+    include ModbusHelpers
+
+
     before do
-        @task = syskit_deploy(
+        @task, @reader, @writer = iodrivers_base_prepare(
             OroGen.water_probe_acquanativa_ap3.Task
-                  .deployed_as_unmanaged("water_probe_acquanativa_ap3_test")
+                . deployed_as("water_probe_acquanativa_ap3_test")
         )
+
+        modbus_helpers_setup(@task, @reader, @writer)
     end
 
     describe "test component configure" do
-        it "checks for io_port setting obligatoriness" do
-            task.properties.device_address = 0
-            expect_execution.scheduler(true).to { fail_to_start task }
-        end
-
         it "cheks for device address setting obligatoriness" do
-            task.properties.io_port = "serial:///dev/ttyDUMMY:9600"
             expect_execution.scheduler(true).to { fail_to_start task }
         end
     end
+
 end

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -54,16 +54,16 @@ describe OroGen.water_probe_acquanativa_ap3.Task do
 
     def get_expected_sample
         sample = Types.water_probe_acquanativa_ap3.ProbeMeasurements.new
-        sample.concentration = @probe_measurements_raw[0] * 1e-5
-        sample.saturation = @probe_measurements_raw[1] * 1e-2
+        sample.oxygen_concentration = @probe_measurements_raw[0] * 1e-8
+        sample.oxygen_saturation = @probe_measurements_raw[1] * 1e-4
         sample.temperature.kelvin = 275.15;
-        sample.ph = @probe_measurements_raw[3] * 1e-2;
+        sample.pH = @probe_measurements_raw[3] * 1e-2;
         sample.conductivity = @probe_measurements_raw[4] * 1e-10;
         sample.salinity = @probe_measurements_raw[5] * 1e-2
-        sample.dissolved_solids = @probe_measurements_raw[6] * 1e-2
+        sample.dissolved_solids = @probe_measurements_raw[6] * 1e-8
         sample.specific_gravity = @probe_measurements_raw[7] * 1e-2
-        sample.ORP = @probe_measurements_raw[8] * 1e-3
-        sample.turbity = @probe_measurements_raw[9]
+        sample.oxidation_reduction_potential = @probe_measurements_raw[8] * 1e-3
+        sample.turbidity = @probe_measurements_raw[9]
         sample.height = @probe_measurements_raw[10]
         sample.latitude = @probe_measurements_raw[11] * 1e-2
         sample.longitude = @probe_measurements_raw[12] * 1e-2

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -77,13 +77,13 @@ describe OroGen.water_probe_acquanativa_ap3.Task do
             modbus_expect_execution(@writer, @reader) do
                 mock_all_sensor_registers
             end.to do
-                have_one_new_sample task.data_port
+                have_one_new_sample task.probe_measurements_port
             end
         end
 
         it "fail when measurements are not avaiable" do
             modbus_expect_execution(@writer, @reader) do
-                have_no_new_sample task.data_port, at_least_during: 0.5
+                have_no_new_sample task.probe_measurements_port, at_least_during: 0.5
             end
         end
 

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -81,14 +81,6 @@ describe OroGen.water_probe_acquanativa_ap3.Task do
             end
         end
 
-        it "successfully read all measurements" do
-            modbus_expect_execution(@writer, @reader) do
-                mock_all_sensor_registers
-            end.to do
-                have_one_new_sample task.data_port
-            end
-        end
-
         it "fail when measurements are not avaiable" do
             modbus_expect_execution(@writer, @reader) do
                 have_no_new_sample task.data_port

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -21,16 +21,16 @@ describe OroGen.water_probe_acquanativa_ap3.Task do
 
     def mock_all_sensor_registers
         registers = {
-            "dissolved_oxygen" => 0,
-            "dissolved_oxygen_sat" => 1,
+            "oxygen_concentration" => 0,
+            "oxygen_saturation" => 1,
             "temperature" => 2,
-            "ph" => 3,
+            "pH" => 3,
             "conductivity" => 4,
             "salinity" => 5,
             "dissolved_solids" => 6,
             "specific_gravity" => 7,
-            "orp" => 8,
-            "turbity" => 9,
+            "oxidation_reduction_potential" => 8,
+            "turbidity" => 9,
             "height" => 10,
             "latitude" => 11,
             "longitude" => 12

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -18,6 +18,38 @@ describe OroGen.water_probe_acquanativa_ap3.Task do
 
     include ModbusHelpers
 
+    def mock_all_sensor_registers
+        registers = {
+            "dissolved_oxygen" => 0,
+            "dissolved_oxygen_sat" => 1,
+            "temperature" => 2,
+            "ph" => 3,
+            "conductivity" => 4,
+            "salinity" => 5,
+            "dissolved_solids" => 6,
+            "specific_gravity" => 7,
+            "orp" => 8,
+            "turbity" => 9,
+            "height" => 10,
+            "latitude" => 11,
+            "longitude" => 12
+        }
+
+        max_value = 2**16
+        modbus_set(registers["dissolved_oxygen"], rand(max_value))
+        modbus_set(registers["dissolved_oxygen_sat"], rand(max_value))
+        modbus_set(registers["temperature"], rand(max_value))
+        modbus_set(registers["ph"], rand(max_value))
+        modbus_set(registers["conductivity"], rand(max_value))
+        modbus_set(registers["salinity"], rand(max_value))
+        modbus_set(registers["dissolved_solids"], rand(max_value))
+        modbus_set(registers["specific_gravity"], rand(max_value))
+        modbus_set(registers["orp"], rand(max_value))
+        modbus_set(registers["turbity"], rand(max_value))
+        modbus_set(registers["height"], rand(max_value))
+        modbus_set(registers["latitude"], rand(max_value))
+        modbus_set(registers["longitude"], rand(max_value))
+    end
 
     before do
         @task, @reader, @writer = iodrivers_base_prepare(
@@ -34,4 +66,33 @@ describe OroGen.water_probe_acquanativa_ap3.Task do
         end
     end
 
+    describe "getting new measurements" do
+        before do
+            task.properties.device_address = 57
+            task.properties.io_read_timeout = Time.at(2)
+            modbus_configure_and_start
+        end
+
+        it "successfully read all measurements" do
+            modbus_expect_execution(@writer, @reader) do
+                mock_all_sensor_registers
+            end.to do
+                have_one_new_sample task.data_port
+            end
+        end
+
+        it "successfully read all measurements" do
+            modbus_expect_execution(@writer, @reader) do
+                mock_all_sensor_registers
+            end.to do
+                have_one_new_sample task.data_port
+            end
+        end
+
+        it "fail when measurements are not avaiable" do
+            modbus_expect_execution(@writer, @reader) do
+                have_no_new_sample task.data_port
+            end
+        end
+    end
 end

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -83,8 +83,9 @@ describe OroGen.water_probe_acquanativa_ap3.Task do
 
         it "fail when measurements are not avaiable" do
             modbus_expect_execution(@writer, @reader) do
-                have_no_new_sample task.data_port
+                have_no_new_sample task.data_port, at_least_during: 0.5
             end
         end
+
     end
 end

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -73,6 +73,17 @@ describe OroGen.water_probe_acquanativa_ap3.Task do
             modbus_configure_and_start
         end
 
+        it "check if the sample timestamp is updated" do
+            read_request_time = Time.now
+            sample = modbus_expect_execution(@writer, @reader) do
+                mock_all_sensor_registers
+            end.to do
+                have_one_new_sample task.probe_measurements_port
+            end
+            now = Time.now
+            assert_in_delta(now, sample.time, Time.now - read_request_time)
+        end
+
         it "successfully read all measurements" do
             modbus_expect_execution(@writer, @reader) do
                 mock_all_sensor_registers
@@ -86,6 +97,5 @@ describe OroGen.water_probe_acquanativa_ap3.Task do
                 have_no_new_sample task.probe_measurements_port, at_least_during: 0.5
             end
         end
-
     end
 end

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -1,0 +1,30 @@
+using_task_library "iodrivers_base"
+require "iodrivers_base/orogen_test_helpers"
+
+using_task_library "water_probe_acquanativa_ap3"
+import_types_from "water_probe_acquanativa_ap3"
+
+describe OroGen.water_probe_acquanativa_ap3.Task do
+    include IODriversBase::OroGenTestHelpers
+
+    run_live
+    attr_reader :task
+    before do
+        @task = syskit_deploy(
+            OroGen.water_probe_acquanativa_ap3.Task
+                  .deployed_as_unmanaged("water_probe_acquanativa_ap3_test")
+        )
+    end
+
+    describe "test component configure" do
+        it "checks for io_port setting obligatoriness" do
+            task.properties.device_address = 0
+            expect_execution.scheduler(true).to { fail_to_start task }
+        end
+
+        it "cheks for device address setting obligatoriness" do
+            task.properties.io_port = "serial:///dev/ttyDUMMY:9600"
+            expect_execution.scheduler(true).to { fail_to_start task }
+        end
+    end
+end

--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -37,16 +37,16 @@ describe OroGen.water_probe_acquanativa_ap3.Task do
         }
 
         @probe_measurements_raw = [756, 85, 200, 646, 156, 126, 1256, 32, 40, 3, 500, 1, 76]
-        modbus_set(registers["dissolved_oxygen"], @probe_measurements_raw[0])
-        modbus_set(registers["dissolved_oxygen_sat"], @probe_measurements_raw[1])
+        modbus_set(registers["oxygen_concentration"], @probe_measurements_raw[0])
+        modbus_set(registers["oxygen_saturation"], @probe_measurements_raw[1])
         modbus_set(registers["temperature"], @probe_measurements_raw[2])
-        modbus_set(registers["ph"], @probe_measurements_raw[3])
+        modbus_set(registers["pH"], @probe_measurements_raw[3])
         modbus_set(registers["conductivity"], @probe_measurements_raw[4])
         modbus_set(registers["salinity"], @probe_measurements_raw[5])
         modbus_set(registers["dissolved_solids"], @probe_measurements_raw[6])
         modbus_set(registers["specific_gravity"], @probe_measurements_raw[7])
-        modbus_set(registers["orp"], @probe_measurements_raw[8])
-        modbus_set(registers["turbity"], @probe_measurements_raw[9])
+        modbus_set(registers["oxidation_reduction_potential"], @probe_measurements_raw[8])
+        modbus_set(registers["turbidity"], @probe_measurements_raw[9])
         modbus_set(registers["height"], @probe_measurements_raw[10])
         modbus_set(registers["latitude"], @probe_measurements_raw[11])
         modbus_set(registers["longitude"], @probe_measurements_raw[12])

--- a/water_probe_acquanativa_ap3.orogen
+++ b/water_probe_acquanativa_ap3.orogen
@@ -30,7 +30,7 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
     output_port "data", "water_probe_acquanativa_ap3/ProbeMeasurements"
 
     # Device address in the Modbus bus
-    property "device_address", "int"
+    property "device_address", "/int", -1
 
     # If you want that component's updateHook() to be executed when the "input"
     # port gets data, uncomment this and comment the 'periodic' line

--- a/water_probe_acquanativa_ap3.orogen
+++ b/water_probe_acquanativa_ap3.orogen
@@ -27,7 +27,7 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
     needs_configuration
 
     # Data output, each field reflects a mesurement
-    output_port "data", "water_probe_acquanativa_ap3/ProbeMeasurements"
+    output_port "probe_measurements", "water_probe_acquanativa_ap3/ProbeMeasurements"
 
     # Device address in the Modbus bus
     property "device_address", "/int", -1

--- a/water_probe_acquanativa_ap3.orogen
+++ b/water_probe_acquanativa_ap3.orogen
@@ -2,6 +2,8 @@ name "water_probe_acquanativa_ap3"
 # Optionally declare the version number
 # version "0.1"
 
+using_task_library "iodrivers_base"
+
 # If new data types need to be defined, they have to be put in a separate C++
 # header, and this header will be loaded here
 import_types_from "water_probe_acquanativa_ap3Types.hpp"
@@ -19,7 +21,7 @@ import_types_from "water_probe_acquanativa_ap3/ProbeMeasurements.hpp"
 #
 # The corresponding C++ class can be edited in tasks/Task.hpp and
 # tasks/Task.cpp, and will be put in the water_probe_acquanativa_ap3 namespace.
-task_context "Task" do
+task_context "Task", subclasses: "iodrivers_base::Task" do
     # This is the default from now on, and should not be removed. Rock will
     # transition to a setup where all components use a configuration step.
     needs_configuration
@@ -27,7 +29,7 @@ task_context "Task" do
     # Data output, each field reflects a mesurement
     output_port "data", "water_probe_acquanativa_ap3/ProbeMeasurements"
 
-    # Port for sensor connection
+    # Device address in the Modbus bus
     property "device_address", "int"
 
     # If you want that component's updateHook() to be executed when the "input"

--- a/water_probe_acquanativa_ap3.orogen
+++ b/water_probe_acquanativa_ap3.orogen
@@ -12,11 +12,8 @@ import_types_from "water_probe_acquanativa_ap3Types.hpp"
 #
 # using_library "water_probe_acquanativa_ap3"
 # import_types_from "water_probe_acquanativa_ap3/CustomType.hpp"
-
-# If this project uses data types that are defined in other oroGen projects,
-# these projects should be imported there as well.
-import_types_from "std"
-# import_types_from "base"
+using_library "water_probe_acquanativa_ap3"
+import_types_from "water_probe_acquanativa_ap3/ProbeMeasurements.hpp"
 
 # Declare a new task context (i.e., a component)
 #
@@ -27,24 +24,11 @@ task_context "Task" do
     # transition to a setup where all components use a configuration step.
     needs_configuration
 
-    # A configuration property (here, a std::string). Its value can be retrieved
-    # in the C++ code with # _config_value.get() and _config_value.set(new_value).
-    property "config_value", "/std/string"
+    # Data output, each field reflects a mesurement
+    output_port "data", "water_probe_acquanativa_ap3/ProbeMeasurements"
 
-    # An input port, i.e. an object from which the component gets data from
-    # other components' outputs
-    #
-    # Data can be retrieved using _input.read(value), which returns true if data
-    # was available, and false otherwise. _input.connected() returns if this
-    # input is connected to an output or not.
-    input_port "input", "/std/string"
-
-    # An output port, i.e. an object to which the component pushes data so that
-    # it is transmitted to other components' inputs
-    #
-    # Data can be written using _output.write(value). _output.connected() returns
-    # if this output is connected to an input or not.
-    output_port "output", "int"
+    # Port for sensor connection
+    property "device_address", "int"
 
     # If you want that component's updateHook() to be executed when the "input"
     # port gets data, uncomment this and comment the 'periodic' line
@@ -52,4 +36,3 @@ task_context "Task" do
     # By default, the task will be periodic with a period of 0.1
     periodic 0.1
 end
-


### PR DESCRIPTION
Depends on:
  - [ ]  https://github.com/tidewise/drivers-water_probe_acquanativa_ap3/pull/1

Definition of the water_probe_acquanativa_ap3 driver's orogen component. The component is a data source that pools the sensor every 0.1s and publishes the raw data into its `_data` output port.