### PR TITLE
fix: allow some retries before bailing out on I/O timeout

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -17,8 +17,6 @@ Task::~Task()
 {
 }
 
-
-
 /// The following lines are template definitions for the various state machine
 // hooks defined by Orocos::RTT. See Task.hpp for more detailed
 // documentation about them.
@@ -26,19 +24,19 @@ Task::~Task()
 bool Task::configureHook()
 {
     const int device_modbus_address = _device_address.get();
-    if(device_modbus_address < 0) {
+    if (device_modbus_address < 0) {
         return false;
     }
-    std::unique_ptr<Driver> driver( new Driver(device_modbus_address));
+    std::unique_ptr<Driver> driver(new Driver(device_modbus_address));
 
     iodrivers_base::ConfigureGuard guard(this);
 
     const std::string device_port = _io_port.get();
-    if(not device_port.empty())
+    if (not device_port.empty())
         driver->openURI(device_port);
 
     setDriver(driver.get());
-    if (! TaskBase::configureHook())
+    if (!TaskBase::configureHook())
         return false;
 
     m_driver = std::move(driver);
@@ -49,8 +47,9 @@ bool Task::configureHook()
 
 bool Task::startHook()
 {
-    if (! TaskBase::startHook())
+    if (!TaskBase::startHook())
         return false;
+
     m_timeouts = 0;
     return true;
 }
@@ -84,8 +83,7 @@ void Task::cleanupHook()
     TaskBase::cleanupHook();
 }
 
-void
-Task::processIO()
+void Task::processIO()
 {
     // Because that Modbus is a master/slave protocol, this method is never called in the
     // iodrivers_base::Task. So it is left empty.

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -31,6 +31,7 @@ tasks/Task.cpp, and will be put in the water_probe_acquanativa_ap3 namespace.
     protected:
         std::unique_ptr<Driver> m_driver;
 
+        int m_timeouts = 0;
 
     public:
         /** TaskContext constructor for Task

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -6,12 +6,15 @@
 #include "water_probe_acquanativa_ap3/TaskBase.hpp"
 #include <water_probe_acquanativa_ap3/Driver.hpp>
 
-namespace water_probe_acquanativa_ap3{
+namespace water_probe_acquanativa_ap3 {
 
     /*! \class Task
-     * \brief The task context provides and requires services. It uses an ExecutionEngine to perform its functions.
-     * Essential interfaces are operations, data flow ports and properties. These interfaces have been defined using the oroGen specification.
-     * In order to modify the interfaces you should (re)use oroGen and rely on the associated workflow.
+     * \brief The task context provides and requires services. It uses an ExecutionEngine
+to perform its functions.
+     * Essential interfaces are operations, data flow ports and properties. These
+interfaces have been defined using the oroGen specification.
+     * In order to modify the interfaces you should (re)use oroGen and rely on the
+associated workflow.
      * Declare a new task context (i.e., a component)
 
 The corresponding C++ class can be edited in tasks/Task.hpp and
@@ -23,11 +26,12 @@ tasks/Task.cpp, and will be put in the water_probe_acquanativa_ap3 namespace.
          task('custom_task_name','water_probe_acquanativa_ap3::Task')
      end
      \endverbatim
-     *  It can be dynamically adapted when the deployment is called with a prefix argument.
+     *  It can be dynamically adapted when the deployment is called with a prefix
+argument.
      */
-    class Task : public TaskBase
-    {
-	friend class TaskBase;
+    class Task : public TaskBase {
+        friend class TaskBase;
+
     protected:
         std::unique_ptr<Driver> m_driver;
 
@@ -35,14 +39,15 @@ tasks/Task.cpp, and will be put in the water_probe_acquanativa_ap3 namespace.
 
     public:
         /** TaskContext constructor for Task
-         * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
-         * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
+         * \param name Name of the task. This name needs to be unique to make it
+         * identifiable via nameservices. \param initial_state The initial TaskState of
+         * the TaskContext. Default is Stopped state.
          */
         Task(std::string const& name = "water_probe_acquanativa_ap3::Task");
 
         /** Default deconstructor of Task
          */
-	~Task();
+        ~Task();
 
         /** This hook is called by Orocos when the state machine transitions
          * from PreOperational to Stopped. If it returns false, then the
@@ -107,4 +112,3 @@ tasks/Task.cpp, and will be put in the water_probe_acquanativa_ap3 namespace.
 }
 
 #endif
-

--- a/water_probe_acquanativa_ap3.orogen
+++ b/water_probe_acquanativa_ap3.orogen
@@ -29,8 +29,14 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
     # Data output, each field reflects a mesurement
     output_port "probe_measurements", "water_probe_acquanativa_ap3/ProbeMeasurements"
 
+    # Amount of consecutive timeouts allowed before the component enters the
+    # TIMEOUT state
+    property "max_consecutive_timeouts", "/int", 10
+
     # Device address in the Modbus bus
     property "device_address", "/int", -1
+
+    exception_states :TIMEOUT
 
     # If you want that component's updateHook() to be executed when the "input"
     # port gets data, uncomment this and comment the 'periodic' line

--- a/water_probe_acquanativa_ap3.orogen
+++ b/water_probe_acquanativa_ap3.orogen
@@ -28,5 +28,5 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
     # port gets data, uncomment this and comment the 'periodic' line
     # port_driven "input"
     # By default, the task will be periodic with a period of 0.1
-    periodic 0.1
+    periodic 3
 end

--- a/water_probe_acquanativa_ap3.orogen
+++ b/water_probe_acquanativa_ap3.orogen
@@ -1,26 +1,12 @@
 name "water_probe_acquanativa_ap3"
-# Optionally declare the version number
-# version "0.1"
 
 using_task_library "iodrivers_base"
 
-# If new data types need to be defined, they have to be put in a separate C++
-# header, and this header will be loaded here
 import_types_from "water_probe_acquanativa_ap3Types.hpp"
-# Finally, it is pretty common that headers are directly loaded from an external
-# library. In this case, the library must be first used (the name is the
-# library's pkg-config name) and then the header can be used. Following Rock
-# conventions, a common use-case would be:
-#
-# using_library "water_probe_acquanativa_ap3"
-# import_types_from "water_probe_acquanativa_ap3/CustomType.hpp"
+
 using_library "water_probe_acquanativa_ap3"
 import_types_from "water_probe_acquanativa_ap3/ProbeMeasurements.hpp"
 
-# Declare a new task context (i.e., a component)
-#
-# The corresponding C++ class can be edited in tasks/Task.hpp and
-# tasks/Task.cpp, and will be put in the water_probe_acquanativa_ap3 namespace.
 task_context "Task", subclasses: "iodrivers_base::Task" do
     # This is the default from now on, and should not be removed. Rock will
     # transition to a setup where all components use a configuration step.


### PR DESCRIPTION

It seems that the controller's modbus communication is unreliable,
and will regularly not answer our commands. Allow for some retries
before we enter an exception state.