### PR TITLE
fix: make the probe task periodic with a 5s period by default

### DIFF
--- a/test/task_test.rb
+++ b/test/task_test.rb
@@ -119,7 +119,7 @@ describe OroGen.water_probe_acquanativa_ap3.Task do
 
         it "fail when measurements are not avaiable" do
             modbus_expect_execution(@writer, @reader) do
-                have_no_new_sample task.probe_measurements_port, at_least_during: 0.5
+                have_no_new_sample task.probe_measurements_port, at_least_during: 3.5
             end
         end
     end

--- a/water_probe_acquanativa_ap3.orogen
+++ b/water_probe_acquanativa_ap3.orogen
@@ -36,5 +36,5 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
     # port gets data, uncomment this and comment the 'periodic' line
     # port_driven "input"
     # By default, the task will be periodic with a period of 0.1
-    periodic 0.1
+    periodic 5
 end

--- a/water_probe_acquanativa_ap3.orogen
+++ b/water_probe_acquanativa_ap3.orogen
@@ -35,6 +35,6 @@ task_context "Task", subclasses: "iodrivers_base::Task" do
     # If you want that component's updateHook() to be executed when the "input"
     # port gets data, uncomment this and comment the 'periodic' line
     # port_driven "input"
-    # By default, the task will be periodic with a period of 0.1
-    periodic 5
+    # By default, the task will be periodic with a period of 5
+    periodic 3
 end


### PR DESCRIPTION
10 Hz makes little sense for a probe like this. Also, trying to figure out whether this would help with the probe
breaking (returning bad values and/or failing to answer)
